### PR TITLE
Adds #unshift to hash

### DIFF
--- a/lib/pretty_ruby.rb
+++ b/lib/pretty_ruby.rb
@@ -176,6 +176,18 @@ module PrettyRuby
 
   end
 
+  refine Hash do
+    def unshift(key_val_pair)
+      key = key_val_pair[0]
+      val = key_val_pair[1]
+      old = self.dup
+      self.clear
+      self[key] = val
+      self.merge! old
+      return self
+    end
+  end
+
   #TODO: add separate tests for this
   refine ::Enumerable do
 

--- a/test/pretty_ruby_test.rb
+++ b/test/pretty_ruby_test.rb
@@ -225,6 +225,29 @@ describe 'Array' do
 
 end
 
+describe 'Hash' do
+  before do
+    @hash = {item: 'Hot Dog', price: 3.5, denomination: 'USD'}
+  end
+
+  describe "without refinement" do
+
+    describe "#unshift" do
+      it "raises" do
+        ->() { @hash.unshift [:condiment, 'mustard'] }.must_raise NoMethodError
+      end
+    end
+  end
+
+  using PrettyRuby
+
+  describe "#unshift" do
+    it 'adds a key-value pair to the "beginning" of a hash' do
+      @hash.unshift([:condiment, 'mustard']).must_equal({condiment: 'mustard', item: 'Hot Dog', price: 3.5, denomination: 'USD'})
+      # @hash.unshift([:condiment, 'mustard']).must_equal([:condiment, 'mustard'])
+    end
+  end
+end
 __END__
 
   refine Enumerable do


### PR DESCRIPTION
Hey @jonahx I was hacking on Ruby with @yananirvana today & we noticed an ugly asymmetry in the Hash API. This PR is designed to rectify the problem

### Context

Hash#shift removes the first key-value pair, returning them as an array

ex.
```
{item: "Hot Dog", price: 3.5, denomination: "USD"}.shift
[:item, "Hot Dog"]
```

Ruby includes no #unshift for hashes (although it does for Arrays) which is
unfair.

### The fix

This PR adds Hash#unshift which takes a key-value pair as an array and adds it
to the hash in the "beginning" position:

ex.
```
{price: 3.5, denomination: "USD"}.unshift [:item, "Hot Dog"]
{item: "Hot Dog", price: 3.5, denomination: "USD"}
```